### PR TITLE
Add MCP scaffolding

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,5 @@
+// Boilerplate MCP configuration
+{
+  "version": 1,
+  "projects": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- After making changes, run `yarn test` and include the output in the PR.
+- Summaries should cite relevant files using the provided citation format.
+- Always ensure the working tree is clean before committing.

--- a/src/vscode/index.ts
+++ b/src/vscode/index.ts
@@ -3,3 +3,4 @@ export * from "./extensions";
 export * from "./launch-config";
 export * from "./settings";
 export * from "./vscode";
+export * from "./mcp";

--- a/src/vscode/mcp.ts
+++ b/src/vscode/mcp.ts
@@ -6,7 +6,13 @@ import { JsonFile } from "../json";
  * MCP configuration for VS Code workspaces.
  */
 export class VsCodeMcp extends Component {
-  private readonly content: any;
+* MCP configuration for VS Code workspaces.
+ */
+export class VsCodeMcp extends Component {
+  private readonly content: { version: number; projects: any[] };
+  public readonly file: JsonFile;
+
+  constructor(vscode: VsCode) {
   public readonly file: JsonFile;
 
   constructor(vscode: VsCode) {

--- a/src/vscode/mcp.ts
+++ b/src/vscode/mcp.ts
@@ -1,0 +1,26 @@
+import { VsCode } from "./vscode";
+import { Component } from "../component";
+import { JsonFile } from "../json";
+
+/**
+ * MCP configuration for VS Code workspaces.
+ */
+export class VsCodeMcp extends Component {
+  private readonly content: any;
+  public readonly file: JsonFile;
+
+  constructor(vscode: VsCode) {
+    super(vscode.project);
+
+    this.content = {
+      version: 1,
+      projects: [],
+    };
+
+    this.file = new JsonFile(vscode.project, ".vscode/mcp.json", {
+      allowComments: true,
+      omitEmpty: false,
+      obj: this.content,
+    });
+  }
+}

--- a/src/vscode/vscode.ts
+++ b/src/vscode/vscode.ts
@@ -1,6 +1,7 @@
 import { VsCodeRecommendedExtensions } from "./extensions";
 import { VsCodeLaunchConfig } from "./launch-config";
 import { VsCodeSettings } from "./settings";
+import { VsCodeMcp } from "./mcp";
 import { Component } from "../component";
 import { Project } from "../project";
 
@@ -8,6 +9,7 @@ export class VsCode extends Component {
   private _launchConfig?: VsCodeLaunchConfig;
   private _settings?: VsCodeSettings;
   private _extensions?: VsCodeRecommendedExtensions;
+  private _mcp?: VsCodeMcp;
 
   constructor(project: Project) {
     super(project);
@@ -35,5 +37,13 @@ export class VsCode extends Component {
     }
 
     return this._extensions;
+  }
+
+  public get mcp() {
+    if (!this._mcp) {
+      this._mcp = new VsCodeMcp(this);
+    }
+
+    return this._mcp;
   }
 }

--- a/test/vscode/mcp.test.ts
+++ b/test/vscode/mcp.test.ts
@@ -1,0 +1,21 @@
+import { PROJEN_MARKER } from "../../src/common";
+import { synthSnapshot, TestProject } from "../util";
+
+const MCP_FILE = ".vscode/mcp.json";
+
+test("default mcp config", () => {
+  const project = new TestProject();
+
+  project.vscode?.mcp;
+
+  const output = synthSnapshot(project)[MCP_FILE];
+  expect(output).toMatchObject({
+    [Symbol.for("before-all")]: [
+      { type: "LineComment", value: expect.stringContaining(PROJEN_MARKER) },
+    ],
+  });
+  expect(output).toStrictEqual({
+    version: 1,
+    projects: [],
+  });
+});


### PR DESCRIPTION
## Summary
- generate `.vscode/mcp.json` with standard comment
- validate MCP generation via test

## Testing
- `yarn test` *(fails: Unsupported option name "--check-files")*

------
https://chatgpt.com/codex/tasks/task_e_683f432e5998832d90ce465ff9c13edc